### PR TITLE
Fix Inngest workflow registry imports

### DIFF
--- a/inngest/functions/echoFilesUploaded.ts
+++ b/inngest/functions/echoFilesUploaded.ts
@@ -1,5 +1,5 @@
 // inngest/functions/echoFilesUploaded.ts
-import { inngest } from "@/inngest/client";
+import { inngest } from "@/lib/inngest/client";
 
 export const echoFilesUploaded = inngest.createFunction(
   { id: "echo-files-uploaded" },            // <-- set to the stable ID Inngest expects

--- a/inngest/workflows.ts
+++ b/inngest/workflows.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // inngest/workflows.ts
 
-import { inngest } from "../lib/inngest/client";
+import { inngest } from "@/lib/inngest/client";
 import { sbAdmin } from "../lib/db/server";
 import { loadPolicy } from "../lib/policy";
 import type { CompletePricingPolicy } from "../lib/policy";
@@ -290,6 +290,12 @@ export const quoteCreatedPrepareJobs = inngest.createFunction(
   }
 );
 
+export const cethosCompositePricingShim = inngest.createFunction(
+  { id: "cethos-quote-platform-compute-pricing" },
+  { event: "internal/compute-pricing-shim" },
+  async ({ step, event }) => step.invoke("compute-pricing", event.data)
+);
+
 /**
  * ------------ Export for Netlify Inngest plugin ------------
  */
@@ -298,4 +304,5 @@ export const functions = [
   geminiAnalyze,
   computePricing,
   quoteCreatedPrepareJobs,
+  cethosCompositePricingShim, // TEMP: remove after caller is fixed
 ];


### PR DESCRIPTION
## Summary
- ensure all Inngest functions import the shared client from `@/lib/inngest/client`
- export a temporary shim for the legacy `cethos-quote-platform-compute-pricing` id and include it in the registry so compute pricing is discoverable

## Testing
- pnpm install --frozen-lockfile
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0a1c002fc8330be1ee21da50c67ac