### PR TITLE
Align Inngest workflow exports

### DIFF
--- a/inngest/workflows.ts
+++ b/inngest/workflows.ts
@@ -536,7 +536,7 @@ export const functions = [
   geminiAnalyze,
   computePricing,
   quoteCreatedPrepareJobs,
-  cethosCompositePricingShim, // TEMP: remove after caller is fixed
-  echoFilesUploaded,
-  processUpload,
+  cethosCompositePricingShim,
+  echoFilesUploaded, // stub if present
+  processUpload, // stub if present
 ];

--- a/resolve_pr21_conflicts.patch
+++ b/resolve_pr21_conflicts.patch
@@ -1,0 +1,15 @@
+diff --git a/inngest/workflows.ts b/inngest/workflows.ts
+index da1869a..0bceeac 100644
+--- a/inngest/workflows.ts
++++ b/inngest/workflows.ts
+@@ -536,7 +536,7 @@ export const functions = [
+   geminiAnalyze,
+   computePricing,
+   quoteCreatedPrepareJobs,
+-  cethosCompositePricingShim, // TEMP: remove after caller is fixed
+-  echoFilesUploaded,
+-  processUpload,
++  cethosCompositePricingShim,
++  echoFilesUploaded, // stub if present
++  processUpload, // stub if present
+ ];


### PR DESCRIPTION
## Summary
- align the Inngest workflow export list with the expected ordering and comments
- add a reusable `resolve_pr21_conflicts.patch` that applies the same change

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d231a8e7c48330a3f9d63782112d85